### PR TITLE
Possible fix for issue #31, args.series_id can be  None type, but url…

### DIFF
--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -639,9 +639,12 @@ def list_media_items(args, request, series_name, season, mode, fanart):
     """
     for media in request:
 	
-        series_id = (media['series']['series_id']
-                       if mode == "history"
-                       else args.series_id)
+        if mode == "history":
+            series_id = media['series']['series_id']
+        elif args.series_id:
+            series_id = args.series_id
+        else:
+            series_id = 'None'
 
         queued = (series_id in args.user_data['queue'])
 


### PR DESCRIPTION
Possible fix for issue #31 
args.series_id  can be type None which causes issues later in crunchy_main.py if it gets assigned to info['series_id'].   setdefault() would not catch this, since the key in the dict does exists. I replaced the assignment with an if/elif/else that sets it to the string 'None' instead of type None.  