### PR TITLE
Set watch status (fixes #43)

### DIFF
--- a/resources/lib/crunchy_main.py
+++ b/resources/lib/crunchy_main.py
@@ -173,7 +173,8 @@ def add_item(args,
                              "Year":    info['year'],
                              "episode": info['episode'],
                              "lastplayed": '2000-01-01 '+str(int(info['percent']) / 60).zfill(2)+':'+str(int(info['percent']) % 60).zfill(2)+':00',
-                             "sorttitle":  info['ordering']
+                             "sorttitle":  info['ordering'],
+                             "playcount": int(info['percent'] >= 90 and not isFolder)
                             }
               )
 


### PR DESCRIPTION
With this PR `playcount` ist set to `1` and thus marked as played when 90% or more of an episode has been played.