### PR TITLE
Remove free available indicator  & Translate menu

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -206,3 +206,11 @@ msgstr ""
 msgctxt "#30507"
 msgid "Progress & Watch State"
 msgstr ""
+
+msgctxt "#30508"
+msgid "General"
+msgstr ""
+
+msgctxt "#30509"
+msgid "Behaviour"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -206,3 +206,11 @@ msgstr "Aktiviere Video sortierung"
 msgctxt "#30507"
 msgid "Progress & Watch State"
 msgstr "Fortschritt & Gesehen Status"
+
+msgctxt "#30508"
+msgid "General"
+msgstr "Allgemein"
+
+msgctxt "#30509"
+msgid "Behaviour"
+msgstr "Verhalten"

--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -736,9 +736,6 @@ def list_media_items(args, request, series_name, season, mode, fanart):
                     if (mode == "history" or
                         mode == "queue")
                     else name)
-        name = ("* " + name
-                    if media['free_available'] is False
-                    else name)
         soon = ("Coming Soon - " + series_name
                 + " Episode " + str(media['episode_number'])
                     if mode == "queue"

--- a/resources/lib/crunchy_main.py
+++ b/resources/lib/crunchy_main.py
@@ -96,7 +96,7 @@ def set_info_defaults (args,info):
     # Defaults in dict. Use 'None' instead of None so it is compatible for
     # quote_plus in parseArgs.
     info.setdefault('url',          'None')
-    info.setdefault('thumb',        'None')
+    info.setdefault('thumb',        "DefaultFolder.png")
     info.setdefault('fanart_image',
                     xbmc.translatePath(args._addon.getAddonInfo('fanart')))
     info.setdefault('count',        '0')

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-  <category label="General">
+  <category label="30508">
     <setting id="crunchy_username" type="text" label="30001" default=""/>
     <setting id="crunchy_password" type="text" label="30002" option="hidden" default=""/>
     <setting type="sep" />
@@ -10,7 +10,7 @@
     <setting type="sep" />
     <setting id="change_language" type="select" lvalues="30300|30301|30302|30303|30304|30305|30306|30307|30308|30309|30313" label="30211" default="0" />
   </category>
-  <category label="Behaviour">
+  <category label="30509">
     <setting id="autoresume" type="labelenum" values="ask|auto|no" label="30311" default="ask" />
     <setting id="show_percent" type="bool" label="30507" default="true" />
   </category>


### PR DESCRIPTION
- "You MUST be a Crunchyroll Premium Member!" so marking premium content with "*", is not anymore necessary ?.

- Translate of the menu in settings  (-> update for Dutch and Portuguese (Brazil) is necessary)