### PR TITLE
Allows user to set prefixes for "Premium Content" and "Coming Soon"

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -214,3 +214,11 @@ msgstr ""
 msgctxt "#30509"
 msgid "Behaviour"
 msgstr ""
+
+msgctxt "#30510"
+msgid "Prefix 'Premium Content' as..."
+msgstr ""
+
+msgctxt "#30511"
+msgid "Prefix \'Coming Soon\' as..."
+msgstr ""

--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -736,10 +736,13 @@ def list_media_items(args, request, series_name, season, mode, fanart):
                     if (mode == "history" or
                         mode == "queue")
                     else name)
-        soon = ("Coming Soon - " + series_name
-                + " Episode " + str(media['episode_number'])
+        name = (args._addon.getSetting("prefix_premium") + name
+                    if media['free_available'] is False
+                    else name)
+        soon = (args._addon.getSetting("prefix_coming") + series_name
+                + "Episode " + str(media['episode_number'])
                     if mode == "queue"
-                    else "Coming Soon - Episode "
+                    else args._addon.getSetting("prefix_coming") + "Episode "
                         + str(media['episode_number']))
         # Set the name for upcoming episode
         name = soon if media['available'] is False else name

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,5 +13,7 @@
   <category label="30509">
     <setting id="autoresume" type="labelenum" values="ask|auto|no" label="30311" default="ask" />
     <setting id="show_percent" type="bool" label="30507" default="true" />
+    <setting id="prefix_premium" type="text" label="30510" default="" />
+    <setting id="prefix_coming" type="text" label="30511" default="Coming Soon - " />
   </category>
 </settings>


### PR DESCRIPTION
Also adds language id 30510 and 30511 for those items in English/strings.po

Note here, the "Premium Content" prefix is now defaulted as "" which is the same as none (as per commit #50 ) but allows the user to put it back in if they prefer it (handy to see what new content has arrived, especially when sorting)