### PR TITLE
fix #52 and add adaptive quality

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -43,6 +43,10 @@ msgctxt "#30008"
 msgid "1080p (HD)"
 msgstr ""
 
+msgctxt "#30012"
+msgid "Adaptive (beta)"
+msgstr ""
+
 msgctxt "#30009"
 msgid "Episodes"
 msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -43,6 +43,10 @@ msgctxt "#30008"
 msgid "1080p (HD)"
 msgstr "1080p (HD)"
 
+msgctxt "#30012"
+msgid "Adaptiv (beta)"
+msgstr ""
+
 msgctxt "#30009"
 msgid "Episodes"
 msgstr "Episoden"

--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -1051,7 +1051,7 @@ def start_playback(args):
     """Play video stream with selected quality.
 
     """
-    res_quality = ['low', 'mid', 'high', 'ultra']
+    res_quality = ['low', 'mid', 'high', 'ultra', 'adaptive']
     quality     = res_quality[int(args._addon.getSetting("video_quality"))]
 
     fields = "".join(["media.episode_number,",
@@ -1100,14 +1100,16 @@ def start_playback(args):
             for stream in request['data']['stream_data']['streams']:
                 allurl[stream['quality']] = stream['url']
 
-            if allurl[quality] is not None:
+            if quality in allurl:
                 url = allurl[quality]
-            elif quality == 'ultra' and allurl['high'] is not None:
+            elif quality == 'ultra' and 'high' in allurl:
                 url = allurl['high']
-            elif allurl['mid'] is not None:
+            elif 'mid' in allurl:
                 url = allurl['mid']
-            else:
+            elif 'low' in allurl:
                 url = allurl['low']
+            else:
+                url = allurl['adaptive']
 
             item = xbmcgui.ListItem(args.name, path=url)
             # TVShowTitle, Season, and Episode are used by the Trakt.tv add-on to determine what is being played

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,7 +5,7 @@
     <setting id="crunchy_password" type="text" label="30002" option="hidden" default=""/>
     <setting type="sep" />
     <setting id="queue_type" type="enum" lvalues="30009|30010" label="30011" default="0" />
-    <setting id="video_quality" type="select" lvalues="30004|30005|30006|30008" label="30003" default="0" />
+    <setting id="video_quality" type="select" lvalues="30004|30005|30006|30008|30012" label="30003" default="0" />
     <setting id="sort_queue" type="bool" label="30506" default="false" />
     <setting type="sep" />
     <setting id="change_language" type="select" lvalues="30300|30301|30302|30303|30304|30305|30306|30307|30308|30309|30313" label="30211" default="0" />


### PR DESCRIPTION
This pr fixes #52 and also enables playing streams which have their quality set to `adaptive`. As far as I can tell `adaptive` quality is provided for all streams.