### PR TITLE
Set duration correctly (stream info)

### DIFF
--- a/resources/lib/crunchy_main.py
+++ b/resources/lib/crunchy_main.py
@@ -198,6 +198,7 @@ def add_item(args,
         cm.insert(0, (args._lang(30504), 'XBMC.Action(Queue)'))
 
     if not isFolder:
+	li.addStreamInfo('video', {"duration": info['duration']})
         # Let XBMC know this can be played, unlike a folder
         li.setProperty('IsPlayable', 'true')
 

--- a/resources/lib/crunchy_main.py
+++ b/resources/lib/crunchy_main.py
@@ -198,7 +198,7 @@ def add_item(args,
         cm.insert(0, (args._lang(30504), 'XBMC.Action(Queue)'))
 
     if not isFolder:
-	li.addStreamInfo('video', {"duration": info['duration']})
+        li.addStreamInfo('video', {"duration": info['duration']})
         # Let XBMC know this can be played, unlike a folder
         li.setProperty('IsPlayable', 'true')
 


### PR DESCRIPTION
This patch will set the (video) streamInfo with the duration provided by the Crunchyroll API thus fixing #46. Additionally the duration is now displayed next to each episode in the default theme.