### PR TITLE
Fix for broken language change

### DIFF
--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -115,6 +115,10 @@ msgctxt "#30212"
 msgid "Video restricted"
 msgstr "De video is regionaal geblokkeerd"
 
+msgctxt "#30211"
+msgid "Subtitle Language"
+msgstr "Ondertitelingstaal"
+
 msgctxt "#30301"
 msgid "English (US)"
 msgstr "Engels (US)"

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -115,14 +115,6 @@ msgctxt "#30212"
 msgid "Video restricted"
 msgstr "De video is regionaal geblokkeerd"
 
-msgctxt "#30211"
-msgid "Force Language Change"
-msgstr "Forceer taal verandering"
-
-msgctxt "#30300"
-msgid "Default"
-msgstr "Uitgeschakeld"
-
 msgctxt "#30301"
 msgid "English (US)"
 msgstr "Engels (US)"
@@ -158,10 +150,6 @@ msgstr "Spaans (Latijns Amerika)"
 msgctxt "#30309"
 msgid "Espanol (Espana)"
 msgstr "Spaans (Spanje)"
-
-msgctxt "#30310"
-msgid "Done. Force language change is now disabled."
-msgstr "Klaar. De geforceerde taal verandering is nu uitgeschakeld."
 
 msgctxt "#30311"
 msgid "Resume Video Playback"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -120,12 +120,8 @@ msgid "Video restricted"
 msgstr ""
 
 msgctxt "#30211"
-msgid "Force Language Change"
+msgid "Subtitle Language"
 msgstr ""
-
-msgctxt "#30300"
-msgid "Default"
-msgstr "Disabled"
 
 msgctxt "#30301"
 msgid "English (US)"
@@ -161,10 +157,6 @@ msgstr ""
 
 msgctxt "#30309"
 msgid "Espanol (Espana)"
-msgstr ""
-
-msgctxt "#30310"
-msgid "Done. Force language change is now disabled."
 msgstr ""
 
 msgctxt "#30311"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -10,7 +10,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
+"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 #Crunchyroll Login Info
@@ -44,7 +44,7 @@ msgid "1080p (HD)"
 msgstr "1080p (HD)"
 
 msgctxt "#30012"
-msgid "Adaptiv (beta)"
+msgid "Adaptiv (Beta)"
 msgstr ""
 
 msgctxt "#30009"
@@ -120,12 +120,8 @@ msgid "Video restricted"
 msgstr "Video ist Regionsbeschränkt"
 
 msgctxt "#30211"
-msgid "Force Language Change"
-msgstr "Erzwinge Sprachwechsel"
-
-msgctxt "#30300"
-msgid "Default"
-msgstr "Deaktiviert"
+msgid "Subtitle Language"
+msgstr "Untertitelsprache"
 
 msgctxt "#30301"
 msgid "English (US)"
@@ -133,7 +129,7 @@ msgstr "Englisch (US)"
 
 msgctxt "#30302"
 msgid "English (UK)"
-msgstr "Englissh (UK)"
+msgstr "Englisch (UK)"
 
 msgctxt "#30303"
 msgid "Nihongo"
@@ -162,10 +158,6 @@ msgstr "Spanisch (Lateinamerika)"
 msgctxt "#30309"
 msgid "Espanol (Espana)"
 msgstr "Spanisch (Spanien)"
-
-msgctxt "#30310"
-msgid "Done. Force language change is now disabled."
-msgstr "Fertig. Erzwungener Sprachwechsel ist jetzt deaktiviert."
 
 msgctxt "#30311"
 msgid "Resume Video Playback"
@@ -218,3 +210,11 @@ msgstr "Allgemein"
 msgctxt "#30509"
 msgid "Behaviour"
 msgstr "Verhalten"
+
+msgctxt "#30510"
+msgid "Prefix 'Premium Content' as..."
+msgstr "Prefix für 'Premium Inhalt'"
+
+msgctxt "#30511"
+msgid "Prefix \'Coming Soon\' as..."
+msgstr "Prefix für 'Demnächst verfügbar'"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -98,14 +98,6 @@ msgctxt "#30212"
 msgid "Video restricted"
 msgstr "Vídeo restrito"
 
-msgctxt "#30211"
-msgid "Force Language Change"
-msgstr "Forçar Alteração do Idioma"
-
-msgctxt "#30300"
-msgid "Disabled"
-msgstr "Desativado"
-
 msgctxt "#30301"
 msgid "English (US)"
 msgstr "English (US)"

--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -62,7 +62,7 @@ def load_pickle(args):
     """
     notice_msg = args._lang(30200)
 
-    change_language = args._addon.getSetting("change_language")
+    subtitle_language = args._addon.getSetting("subtitle_language")
 
     base_path = xbmc.translatePath(args._addon.getAddonInfo('profile')).decode('utf-8')
 
@@ -85,27 +85,25 @@ def load_pickle(args):
     try:
         # Load persistent vars
 
-        if change_language == "0":
-            user_data.setdefault('API_LOCALE',"enUS")
-        elif change_language == "1":
+        if subtitle_language == "0":
             user_data['API_LOCALE']  = "enUS"
-        elif change_language == "2":
+        elif subtitle_language == "1":
             user_data['API_LOCALE']  = "enGB"
-        elif change_language == "3":
+        elif subtitle_language == "2":
             user_data['API_LOCALE']  = "jaJP"
-        elif change_language == "4":
+        elif subtitle_language == "3":
             user_data['API_LOCALE']  = "frFR"
-        elif change_language == "5":
+        elif subtitle_language == "4":
             user_data['API_LOCALE']  = "deDE"
-        elif change_language == "6":
+        elif subtitle_language == "5":
             user_data['API_LOCALE']  = "ptBR"
-        elif change_language == "7":
+        elif subtitle_language == "6":
             user_data['API_LOCALE']  = "ptPT"
-        elif change_language == "8":
+        elif subtitle_language == "7":
             user_data['API_LOCALE']  = "esLA"
-        elif change_language == "9":
+        elif subtitle_language == "8":
             user_data['API_LOCALE']  = "esES"
-        elif change_language == "10":
+        elif subtitle_language == "9":
             user_data['API_LOCALE']  = "itIT"
 
         user_data['username'] = args._addon.getSetting("crunchy_username")
@@ -1318,70 +1316,6 @@ def makeAPIRequest(args, method, options):
         log("CR: makeAPIRequest: %s %s" % (s, pt), xbmc.LOGERROR)
 
     return request
-
-
-def change_locale(args):
-    """Change locale.
-
-    """
-    cj           = cookielib.LWPCookieJar()
-
-    notice      = args._lang(30200)
-    notice_msg  = args._lang(30211)
-    notice_err  = args._lang(30206)
-    notice_done = args._lang(30310)
-
-    icon = xbmc.translatePath(args._addon.getAddonInfo('icon'))
-
-    ua = 'Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/20100101 Firefox/5.0'
-
-    if (args.user_data['username'] != '' and
-        args.user_data['password'] != ''):
-
-        log("CR: Attempting to log-in with your user account...")
-        xbmc.executebuiltin('Notification(' + notice + ','
-                            + notice_msg + ',5000,' + icon + ')')
-
-        url  = 'https://www.crunchyroll.com/?a=formhandler'
-        data = urllib.urlencode({'formname': 'RpcApiUser_Login',
-                                 'next_url': '',
-                                 'fail_url': '/login',
-                                 'name':     args.user_data['username'],
-                                 'password': args.user_data['password']})
-        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
-        opener.addheaders = [('Referer',    'https://www.crunchyroll.com'),
-                             ('User-Agent', ua)]
-        urllib2.install_opener(opener)
-        req = opener.open(url, data)
-        req.close()
-
-    else:
-        xbmc.executebuiltin('Notification(' + notice + ','
-                            + notice_err + ',5000,' + icon + ')')
-        log("CR: No Crunchyroll account found!")
-
-    url  = 'https://www.crunchyroll.com/?a=formhandler'
-    data = urllib.urlencode({'next_url': '',
-                             'language': args.user_data['API_LOCALE'],
-                             'formname': 'RpcApiUser_UpdateDefaultSoftSubLanguage'})
-    opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
-    opener.addheaders = [('Referer',    'https://www.crunchyroll.com/acct/?action=video'),
-                         ('User-Agent', ua)]
-    urllib2.install_opener(opener)
-
-    # Enter in the video settings page first (doesn't work without it)
-    req = opener.open("https://www.crunchyroll.com/acct/?action=video")
-
-    # Now do the actual language change
-    req = opener.open(url, data)
-    req.close()
-
-    log('CR: Now using ' + args.user_data['API_LOCALE'])
-    xbmc.executebuiltin('Notification(' + notice + ','
-                        + notice_done + ',5000,' + icon + ')')
-    log("CR: Disabling the force change language setting")
-
-    args._addon.setSetting(id="change_language", value="0")
 
 
 def log(msg,

--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -770,7 +770,7 @@ def list_media_items(args, request, series_name, season, mode, fanart):
                         else str(media['duration']))
         # Current playback point
         playhead = ("0"
-                        if media['available'] is False
+                        if (media['available'] is False or not 'playhead' in media)
                         else str(media['playhead']))
 
         # Adding published date instead

--- a/resources/lib/crunchy_main.py
+++ b/resources/lib/crunchy_main.py
@@ -234,11 +234,6 @@ def show_main(args):
     """Show main menu.
 
     """
-    change_language = args._addon.getSetting("change_language")
-
-    if change_language != "0":
-        crj.change_locale(args)
-
     anime   = args._lang(30100)
     drama   = args._lang(30104)
     queue   = args._lang(30105)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,7 +8,7 @@
     <setting id="video_quality" type="select" lvalues="30004|30005|30006|30008|30012" label="30003" default="0" />
     <setting id="sort_queue" type="bool" label="30506" default="false" />
     <setting type="sep" />
-    <setting id="change_language" type="select" lvalues="30300|30301|30302|30303|30304|30305|30306|30307|30308|30309|30313" label="30211" default="0" />
+    <setting id="subtitle_language" type="select" lvalues="30301|30302|30303|30304|30305|30306|30307|30308|30309|30313" label="30211" default="0" />
   </category>
   <category label="30509">
     <setting id="autoresume" type="labelenum" values="ask|auto|no" label="30311" default="ask" />


### PR DESCRIPTION
Hello,

I removed the old language change feature. Now we can set the subtitle language permanent in the addon settings.

We will just set API_LOCALE everytime we load the pickle.
Crunchyroll will automatically deliver the correct subtitles (if available) or fallback to the language set in our Crunchyroll Account (if available). Otherwise enUS.

This fixes issue #56 .

Please test it before merging :)