### PR TITLE
Use native Python HTTPSHandler if it supports SNI

### DIFF
--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -1263,9 +1263,9 @@ def makeAPIRequest(args, method, options):
         values.update(options)
         options = urllib.urlencode(values)
         
-        try:
+        if sys.version_info >= (2, 7, 9):
             handler = urllib2.HTTPSHandler()
-        except AttributeError:
+        else:
             handler = urllib2_ssl.HTTPSHandler(ca_certs=path)
 
         opener = urllib2.build_opener(handler)

--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -1262,8 +1262,13 @@ def makeAPIRequest(args, method, options):
 
         values.update(options)
         options = urllib.urlencode(values)
+        
+        try:
+            handler = urllib2.HTTPSHandler()
+        except AttributeError:
+            handler = urllib2_ssl.HTTPSHandler(ca_certs=path)
 
-        opener = urllib2.build_opener(urllib2_ssl.HTTPSHandler(ca_certs=path))
+        opener = urllib2.build_opener(handler)
         opener.addheaders = args.user_data['API_HEADERS']
         urllib2.install_opener(opener)
 


### PR DESCRIPTION
Kodi 17 is using Python 2.7.10 and `urllib2.HTTPSHandler` is included in Python 2.7.9 or higher.
This PR will make the plugin use `urllib2.HTTPSHandler` instead of `urllib2_ssl.HTTPSHandler` if available.