### PR TITLE
Crash if video not available

### DIFF
--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -1106,6 +1106,10 @@ def start_playback(args):
                 url = allurl['mid']
             elif 'low' in allurl:
                 url = allurl['low']
+            elif not allurl:
+                xbmcgui.Dialog().notification("Crunchyroll", "Sorry, this video is not available yet.", xbmcgui.NOTIFICATION_INFO)
+                log("CR: start_playback: this video is not available yet..")
+                return
             else:
                 url = allurl['adaptive']
 

--- a/resources/lib/crunchy_json.py
+++ b/resources/lib/crunchy_json.py
@@ -1098,6 +1098,7 @@ def start_playback(args):
             for stream in request['data']['stream_data']['streams']:
                 allurl[stream['quality']] = stream['url']
 
+            log("CR: start_playback: streams found: " + str(allurl), xbmc.LOGDEBUG)
             if quality in allurl:
                 url = allurl[quality]
             elif quality == 'ultra' and 'high' in allurl:
@@ -1106,12 +1107,13 @@ def start_playback(args):
                 url = allurl['mid']
             elif 'low' in allurl:
                 url = allurl['low']
-            elif not allurl:
+            elif 'adaptive' in allurl:
+                url = allurl['adaptive']
+            else:
+				# none of the above qualities found
                 xbmcgui.Dialog().notification("Crunchyroll", "Sorry, this video is not available yet.", xbmcgui.NOTIFICATION_INFO)
                 log("CR: start_playback: this video is not available yet..")
                 return
-            else:
-                url = allurl['adaptive']
 
             item = xbmcgui.ListItem(args.name, path=url)
             # TVShowTitle, Season, and Episode are used by the Trakt.tv add-on to determine what is being played


### PR DESCRIPTION
It can happen, that crunchyroll publish a video, but the pre encoded streams are not ready yet.
The API says that the video is available but not provide the video urls.
Which means the array 'allurl' will be empty.

Crash Log: https://gist.github.com/MrKrabat/a246f7f05281f8e52e0a5aaafa342392

This case occurs extremely rare. I guess other languages than english are more often affected.
The official windows 10 app also return an error for this episodes (since it also use the pre encoded streams).
Viewing in browser works of course.

Instead of a crash the user will now see a notification.
(but sometimes kodi put a "playback not possible" message above it)