### PR TITLE
Configurable context menu

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -218,3 +218,59 @@ msgstr ""
 msgctxt "#30511"
 msgid "Prefix \'Coming Soon\' as..."
 msgstr ""
+
+msgctxt "#30512"
+msgid "Toggle Debug"
+msgstr ""
+
+msgctxt "#30513"
+msgid "Set to 100% played"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Set to 0% played"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Kodi default menu"
+msgstr ""
+
+msgctxt "#30520"
+#Will have a quality appended to it, "Play at" will be shown like "Play at 480p"
+msgid "Play at"
+msgstr ""
+
+msgctxt "#30521"
+#Will have a timestamp applied to it, "Play at" will be shown like "Play from 00:12:25"
+msgid "Play from"
+msgstr ""
+
+msgctxt "#30600"
+#Negative answer
+msgid "No"
+msgstr ""
+
+msgctxt "#30601"
+#Affirmative answer
+msgid "Yes"
+msgstr ""
+
+msgctxt "#30602"
+#Indicate that the add-on should ask
+msgid "Ask"
+msgstr ""
+
+msgctxt "#30603"
+#On / Activated (opposite of "off")
+msgid "On"
+msgstr ""
+
+msgctxt "#30604"
+#Off / Not activated (opposite of "on")
+msgid "Off"
+msgstr ""
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-  <category label="30508">
+  <category label="30508"> <!-- General -->
     <setting id="crunchy_username" type="text" label="30001" default=""/>
     <setting id="crunchy_password" type="text" label="30002" option="hidden" default=""/>
     <setting type="sep" />
@@ -10,10 +10,23 @@
     <setting type="sep" />
     <setting id="subtitle_language" type="select" lvalues="30301|30302|30303|30304|30305|30306|30307|30308|30309|30313" label="30211" default="0" />
   </category>
-  <category label="30509">
-    <setting id="autoresume" type="labelenum" values="ask|auto|no" label="30311" default="ask" />
+  <category label="30509"> <!-- Behaviour -->
+    <setting id="autoresume" type="enum" lvalues="30600|30601|30602" label="30311" default="2" /> <!-- no|yes|ask default=ask -->
     <setting id="show_percent" type="bool" label="30507" default="true" />
     <setting id="prefix_premium" type="text" label="30510" default="" />
     <setting id="prefix_coming" type="text" label="30511" default="Coming Soon - " />
   </category>
+  <category label="30515"> <!-- Context menu -->
+    <setting id="CM_kodi" type="bool" label="30519" default="false" />
+    <setting id="CM_queueV" type="bool" label="30504" default="true" /> 
+    <setting id="CM_playAt" type="select" lvalues="30604|30004|30005|30006|30008|30012" label="30520" default="0" /> <!-- keep order same as video_quality (above), prefix with off (30604) -->
+    <setting id="CM_playFrom" type="bool" label="30521" default="false" />
+    <setting id="CM_enqueueS" type="bool" label="30502" default="true" />
+    <setting id="CM_dequeueS" type="bool" label="30501" default="true" />
+    <setting id="CM_watched" type="bool" label="30513" default="false" />
+    <setting id="CM_unwatched" type="bool" label="30514" default="false" />
+    <setting id="CM_gotoS" type="bool" label="30503" default="true" />
+    <setting id="CM_settings" type="bool" label="30505" default="true" />
+    <setting id="CM_toggledebug" type="bool" label="30512" default="true" />
+  </category> 
 </settings>


### PR DESCRIPTION
Makes the context menu configurable (with new tab in settings)
(adds quite a bit of new entries in language/English as well)

New features selectable:
* "Set to 100% played" - report to CR that watched time is duration

* "Set to 0% played" - report to CR that 0s has been watched

* "Play at ..." - Play this episide at a different quality

* "Kodi internal" - Keep the kodi menu (allows for favourites)

* "play from ..." - Will play from either CR-resumepoint or from start
  (from start if more than 90% watched or if autoresume is set to yes)